### PR TITLE
Simplify build

### DIFF
--- a/com.valvesoftware.Steam.Utility.MangoHud.yml
+++ b/com.valvesoftware.Steam.Utility.MangoHud.yml
@@ -17,22 +17,16 @@ build-options:
     C_INCLUDE_PATH: /app/utils/MangoHud/include
     CPLUS_INCLUDE_PATH: /app/utils/MangoHud/include
   strip: true
-cleanup:
-  - /share/vulkan/implicit_layer.d/MangoHud.json
 modules:
 
   - name: MangoHud
+    build-options:
+      libdir: lib/x86_64-linux-gnu
     buildsystem: meson
     config-opts: &mangohud-config-opts
       - -Duse_system_vulkan=enabled
       - -Dwith_xnvctrl=disabled
-    post-install:
-      - |
-        sed \
-            -e 's/\\$LIB/lib/' \
-            -e 's/"name": "\(.*\)"/"name": "\1_native"/' \
-            ${FLATPAK_DEST}/share/vulkan/implicit_layer.d/MangoHud.json > \
-            ${FLATPAK_DEST}/share/vulkan/implicit_layer.d/MangoHud_native.json
+      - -Dappend_libdir_mangohud=true
     sources: &mangohud-sources
       - type: git
         url: "https://github.com/flightlessmango/MangoHud.git"
@@ -57,25 +51,14 @@ modules:
       env:
         CC: ccache i686-unknown-linux-gnu-gcc
         CXX: ccache i686-unknown-linux-gnu-g++
-      libdir: /app/utils/MangoHud/lib32
+      libdir: lib/i386-linux-gnu
     buildsystem: meson
     config-opts: *mangohud-config-opts
-    post-install:
-      - |
-        sed \
-            -e 's/\\$LIB/lib32/' \
-            -e 's/"name": "\(.*\)"/"name": "\1_compat32"/' \
-            ${FLATPAK_DEST}/share/vulkan/implicit_layer.d/MangoHud.json > \
-            ${FLATPAK_DEST}/share/vulkan/implicit_layer.d/MangoHud_compat32.json
     sources: *mangohud-sources
 
   - name: metadata
     buildsystem: simple
     build-commands:
-      - |
-        sed \
-            "s|${FLATPAK_DEST}/\\\\\$LIB/mangohud/|${FLATPAK_DEST}/lib32/mangohud/:${FLATPAK_DEST}/lib/mangohud/|" \
-            -i ${FLATPAK_DEST}/bin/mangohud
       - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
       - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
     sources:


### PR DESCRIPTION
Since it's an extension with unique prefix, we can put out libs under paths with arch triplets, and, thus make `$LIB` work. This removes the need to have separate per-arch layer manifests.